### PR TITLE
Connect web UI to live display data

### DIFF
--- a/drawImage.py
+++ b/drawImage.py
@@ -53,11 +53,15 @@ class GatherValues:
         logging.info("Calculating regular value")
         planRemaining = float(hughesnet_values['planRemaining'])
         planTotal = float(hughesnet_values['planTotal'])
+        self.planRemaining = planRemaining
+        self.planTotal = planTotal
         self.planPercentRemaining = round((planRemaining / planTotal) * 100, 2)
         
         logging.info("Calculating bonus value")
         bonusRemaining = float(hughesnet_values['bonusRemaining'])
         bonusTotal = float(hughesnet_values['bonusTotal'])
+        self.bonusRemaining = bonusRemaining
+        self.bonusTotal = bonusTotal
         self.bonusPercentRemaining = round((bonusRemaining / bonusTotal) * 100, 2)
 
         logging.info("Getting IP Address of device")

--- a/main.py
+++ b/main.py
@@ -1,10 +1,25 @@
 #!/usr/bin/python
 import drawImage
+import json
+import os
 
 def main(debug: bool):
     values = drawImage.GatherValues(debug)
 
     drawImage.DrawImage(values.todays_date, values.lastUpdated_dateTime, values.planPercentRemaining, values.bonusPercentRemaining, values.random_fact, values.web_address)
+
+    data = {
+        'plan_total': values.planTotal,
+        'plan_remaining': values.planRemaining,
+        'bonus_total': values.bonusTotal,
+        'bonus_remaining': values.bonusRemaining,
+        'plan_percentage': values.planPercentRemaining,
+        'bonus_percentage': values.bonusPercentRemaining,
+        'fun_fact': values.random_fact
+    }
+    data_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'latest_data.json')
+    with open(data_path, 'w') as f:
+        json.dump(data, f)
 
 if __name__ == "__main__":
     main(debug=True)

--- a/src/web/templates/home.html
+++ b/src/web/templates/home.html
@@ -58,6 +58,12 @@
     border-radius: 5px;
     width: 80%;
     margin: 5px 0 10px;
+    position: relative;
+  }
+  .progress-fill {
+    height: 100%;
+    background: linear-gradient(90deg, #6184FF 0%, #2FB4FF 100%);
+    border-radius: 5px;
   }
 
   .control-sections {
@@ -137,14 +143,14 @@
   <div class="grid-container">
     <div class="section Regularplan">
       <div class="section-title">Regular Plan</div>
-      <div class="progressbar"></div>
-      <div>20% remaining</div>
+      <div class="progressbar"><div class="progress-fill" style="width: {{ regular_percentage }}%"></div></div>
+      <div>{{ regular_percentage }}% remaining</div>
     </div>
     
     <div class="section Bonusplan">
       <div class="section-title">Bonus Plan</div>
-      <div class="progressbar"></div>
-      <div>20% remaining</div>
+      <div class="progressbar"><div class="progress-fill" style="width: {{ bonus_percentage }}%"></div></div>
+      <div>{{ bonus_percentage }}% remaining</div>
     </div>
     
     <div class="section Timeremaining">
@@ -155,7 +161,7 @@
     
     <div class="section Funfact">
       <div class="section-title">Fun Fact</div>
-      <div>Honey never spoils. Ancient Egyptians ate edible honey thousands of years old.</div>
+      <div>{{ fun_fact|join('<br>') }}</div>
     </div>
   </div>
 

--- a/web.py
+++ b/web.py
@@ -4,6 +4,6 @@ import main
 
 
 
-Server = Webserver(lambda: main.main(debug=True))
+Server = Webserver(lambda: main.main(debug=False))
 
-Server.start_server(80, 24, 80, 24)
+Server.start_server()


### PR DESCRIPTION
## Summary
- track scraped plan usage info in `GatherValues`
- save latest usage data and fun fact when refreshing the display
- serve current data from `latest_data.json` in the web app
- update HTML to display progress bars and fun fact dynamically
- start the webserver without placeholder numbers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python web.py` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684a34f8fc008326ad0eb33a5cfada25